### PR TITLE
Added album name support.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,13 +1,13 @@
-platform :osx, '10.10'
+platform :osx, '10.11'
 use_frameworks!
 
 target 'SpotMenu' do
-    pod 'SpotifyAppleScript', '~> 0.3'
+    pod 'SpotifyAppleScript', :git => 'https://github.com/kmikiy/SpotifyAppleScript'
     pod 'Sparkle'
     pod 'LoginServiceKit', :git => 'https://github.com/Clipy/LoginServiceKit.git'
 end
 
 target 'SpotMenuToday' do
-    pod 'SpotifyAppleScript', '~> 0.3'
+    pod 'SpotifyAppleScript', :git => 'https://github.com/kmikiy/SpotifyAppleScript'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,22 +6,27 @@ PODS:
 DEPENDENCIES:
   - LoginServiceKit (from `https://github.com/Clipy/LoginServiceKit.git`)
   - Sparkle
-  - SpotifyAppleScript (~> 0.3)
+  - SpotifyAppleScript (from `https://github.com/kmikiy/SpotifyAppleScript`)
 
 EXTERNAL SOURCES:
   LoginServiceKit:
     :git: https://github.com/Clipy/LoginServiceKit.git
+  SpotifyAppleScript:
+    :git: https://github.com/kmikiy/SpotifyAppleScript
 
 CHECKOUT OPTIONS:
   LoginServiceKit:
     :commit: 2f85790d6ec22e229dcbbf01bb4e4afe8e4e9a2b
     :git: https://github.com/Clipy/LoginServiceKit.git
+  SpotifyAppleScript:
+    :commit: ef4fe14fe202de196b886c79997408cbcb284cc3
+    :git: https://github.com/kmikiy/SpotifyAppleScript
 
 SPEC CHECKSUMS:
   LoginServiceKit: 1282b6588b77a8a201d6ed6c7c608f492c2e2c3d
   Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
-  SpotifyAppleScript: 1082f8920e720fe5a20e71c088bccb568e71a12a
+  SpotifyAppleScript: 9e0c8f32d51ed8345db8b916f4fb379be97ea185
 
-PODFILE CHECKSUM: 809f1ecb9bcdaee5ca6fa40b55a2e949b39b360d
+PODFILE CHECKSUM: 91442251023e0c5b744a6ca9cc8af1d09c5c4238
 
 COCOAPODS: 1.3.1

--- a/SpotMenu.xcodeproj/project.pbxproj
+++ b/SpotMenu.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -432,12 +432,12 @@
 					213324271D79801E0060D48C = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Manual;
 					};
 					64185C0B1F1B8DC400CA23A0 = {
 						CreatedOnToolsVersion = 8.3.3;
-						DevelopmentTeam = 3K79XCJYWL;
 						LastSwiftMigration = 0900;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 0;
@@ -447,7 +447,7 @@
 				};
 			};
 			buildConfigurationList = 213324231D79801E0060D48C /* Build configuration list for PBXProject "SpotMenu" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -787,11 +787,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SpotMenu/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.KMikiy.SpotMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "SpotMenu/SpotMenu-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -806,11 +810,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SpotMenu/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.KMikiy.SpotMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "SpotMenu/SpotMenu-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -825,8 +833,9 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = SpotMenuToday/SpotMenuToday.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 3K79XCJYWL;
+				DEVELOPMENT_TEAM = "";
 				DevelopmentTeam = 3K79XCJYWL;
 				INFOPLIST_FILE = SpotMenuToday/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
@@ -849,8 +858,9 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = SpotMenuToday/SpotMenuToday.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 3K79XCJYWL;
+				DEVELOPMENT_TEAM = "";
 				DevelopmentTeam = 3K79XCJYWL;
 				INFOPLIST_FILE = SpotMenuToday/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";

--- a/SpotMenu/AppDelegate/AppDelegate.swift
+++ b/SpotMenu/AppDelegate/AppDelegate.swift
@@ -153,6 +153,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let statusItemTitle = StatusItemBuilder()
             .hideTitleArtistWhenPaused(v: UserPreferences.hideTitleArtistWhenPaused)
             .showTitle(v: UserPreferences.showTitle)
+            .showAlbumName(v: UserPreferences.showAlbumName)
             .showArtist(v: UserPreferences.showArtist)
             .showPlayingIcon(v: UserPreferences.showPlayingIcon)
             .getString()

--- a/SpotMenu/Localizable/en.lproj/Localizable.strings
+++ b/SpotMenu/Localizable/en.lproj/Localizable.strings
@@ -12,8 +12,9 @@
 "Quit" = "Quit";
 "Now playing" = "Now playing";
 "Hover over an option for more information." = "Hover over an option for more information.";
-"When checked the Artist will be shown in the menu bar." = "When checked the Artist will be shown in the menu bar.";
-"When checked the Title will be shown in the menu bar." = "When checked the Title will be shown in the menu bar.";
+"When checked the artist will be shown in the menu bar." = "When checked the artist will be shown in the menu bar.";
+"When checked the album name will be shown in the menu bar." = "When checked the album name will be shown in the menu bar.";
+"When checked the title will be shown in the menu bar." = "When checked the title will be shown in the menu bar.";
 "When checked the playing icon (♫) will be shown in the menu bar if music is played." = "When checked the playing icon (♫) will be shown in the menu bar if music is played.";
 "When checked the SpotMenu icon will be shown in the menu bar. Note: If there is no music information to be shown the SpotMenu icon will be visible." = "When checked the SpotMenu icon will be shown in the menu bar.\n\nNote:\nIf there is no music information to be shown the SpotMenu icon will be visible.";
 "When checked the popover will be fixed to the right corner." = "When checked the popover will be fixed to the right corner.";

--- a/SpotMenu/Preferences/Tabs/AboutPreferences.storyboard
+++ b/SpotMenu/Preferences/Tabs/AboutPreferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="BoH-Mq-lW7">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="BoH-Mq-lW7">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,9 +33,9 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" id="95Y-Xy-JBU">
                                                         <font key="font" metaFont="system"/>
-                                                        <string key="title">SpotMenu is free and open source📖. My goal is to keep it this way. I do not want to limit functions, nor annoy users. Unfortunately, I like money💰💵🤑 and would like to live a lavish lifestyle💎. 
+                                                        <mutableString key="title">SpotMenu is free and open source📖. My goal is to keep it this way. I do not want to limit functions, nor annoy users. Unfortunately, I like money💰💵🤑 and would like to live a lavish lifestyle💎. 
 I have included a picture of me from the future (it is NOT photoshopped)🌅. For those who would like to contribute to my wellbeing and fulfilling my destiny I have included several ways to donate that sweet sweet money.
-Ya boy, kmikiy now accepts several cryptocurrencies.</string>
+Ya boy, kmikiy now accepts several cryptocurrencies.</mutableString>
                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>

--- a/SpotMenu/Preferences/Tabs/GeneralPreferences.storyboard
+++ b/SpotMenu/Preferences/Tabs/GeneralPreferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="oE3-rO-9wI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="oE3-rO-9wI">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,57 +11,47 @@
             <objects>
                 <viewController storyboardIdentifier="GeneralID" id="oE3-rO-9wI" customClass="GeneralPreferencesVC" customModule="SpotMenu" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" identifier="General" id="hd7-oN-oUJ">
-                        <rect key="frame" x="0.0" y="0.0" width="500" height="274"/>
+                        <rect key="frame" x="0.0" y="0.0" width="473" height="343"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Wcp-B2-r4h" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="238" width="218" height="18"/>
+                                <rect key="frame" x="18" y="315" width="205" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show artist" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GCF-Yi-4mg">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="toggleShowArtist:" target="oE3-rO-9wI" id="J4g-GW-V7o"/>
+                                    <action selector="toggleShowArtist:" target="oE3-rO-9wI" id="0Be-Gf-4rB"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="jNP-RL-5Pk" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="218" width="218" height="18"/>
+                                <rect key="frame" x="18" y="295" width="201" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show title" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Oaz-ZO-Byg">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="toggleShowTitle:" target="oE3-rO-9wI" id="aft-VS-SVZ"/>
-                                </connections>
-                            </button>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="yj4-VE-ueY" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="198" width="218" height="18"/>
-                                <buttonCell key="cell" type="check" title="Show playing icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tGG-tK-EIa">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="toggleShowPlayingIcon:" target="oE3-rO-9wI" id="IQZ-aU-hg0"/>
+                                    <action selector="toggleShowTitle:" target="oE3-rO-9wI" id="bhl-m6-Of1"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="6XJ-fx-OKW" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="178" width="218" height="18"/>
+                                <rect key="frame" x="18" y="227" width="204" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show SpotMenu icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="qTn-74-VHm">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="toggleShowSpotMenuIcon:" target="oE3-rO-9wI" id="1Ls-KT-Ofn"/>
+                                    <action selector="toggleShowSpotMenuIcon:" target="oE3-rO-9wI" id="NwR-AW-47l"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="pMj-ay-oKs" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="138" width="218" height="18"/>
+                                <rect key="frame" x="18" y="180" width="204" height="18"/>
                                 <buttonCell key="cell" type="check" title="Fix popover to the right" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hVH-jS-wte">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="toggleFixPopoverToTheRight:" target="oE3-rO-9wI" id="avm-kS-ydO"/>
+                                    <action selector="toggleFixPopoverToTheRight:" target="oE3-rO-9wI" id="xk6-Zz-hgs"/>
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="peo-tz-ZOw">
@@ -73,10 +63,69 @@
                                 </textFieldCell>
                             </textField>
                             <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5fe-rf-Xgk">
-                                <rect key="frame" x="247" y="12" width="5" height="250"/>
+                                <rect key="frame" x="234" y="0.0" width="5" height="343"/>
                             </box>
+                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uyC-Ea-vx3">
+                                <rect key="frame" x="20" y="169" width="200" height="5"/>
+                            </box>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="t8Z-Rd-MFu" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="18" y="127" width="204" height="18"/>
+                                <buttonCell key="cell" type="check" title="Open at login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wOi-2h-h7o">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleOpenAtLogin:" target="oE3-rO-9wI" id="FOF-IZ-0mE"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="ajp-ZJ-7EX" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="18" y="147" width="204" height="18"/>
+                                <buttonCell key="cell" type="check" title="Enable keyboard shortcut" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xI1-dq-8Q7">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleEnableKeyboardShortcut:" target="oE3-rO-9wI" id="Buf-lK-C6B"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="oxy-oE-dHM" userLabel="Hide Text When Paused Button" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="18" y="200" width="196" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="tuk-ov-duS"/>
+                                </constraints>
+                                <buttonCell key="cell" type="check" title="Hide text when paused" bezelStyle="regularSquare" imagePosition="left" inset="2" id="VqI-2W-Oiy">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleHideTextWhenPaused:" target="oE3-rO-9wI" id="zdL-Ko-Bq9"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="yj4-VE-ueY" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="18" y="247" width="204" height="22"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="18" id="XSo-kG-NEH"/>
+                                </constraints>
+                                <buttonCell key="cell" type="check" title="Show playing icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tGG-tK-EIa">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleShowPlayingIcon:" target="oE3-rO-9wI" id="1nf-QN-h9a"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Trq-wg-nYW" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="18" y="271" width="204" height="22"/>
+                                <buttonCell key="cell" type="check" title="Show album name" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="f4T-W3-x7g">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleShowAlbumName:" target="oE3-rO-9wI" id="rKw-yY-SyQ"/>
+                                </connections>
+                            </button>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p7v-xI-0VE">
-                                <rect key="frame" x="263" y="220" width="219" height="34"/>
+                                <rect key="frame" x="243" y="297" width="205" height="34"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Hover over an option for more information" id="oHX-AN-IDS">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -86,74 +135,45 @@
                                     <action selector="toggleFixPopoverToTheRight:" target="oE3-rO-9wI" id="MJ7-5W-3Np"/>
                                 </connections>
                             </textField>
-                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uyC-Ea-vx3">
-                                <rect key="frame" x="20" y="129" width="214" height="5"/>
-                            </box>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="t8Z-Rd-MFu" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="87" width="218" height="18"/>
-                                <buttonCell key="cell" type="check" title="Open at login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wOi-2h-h7o">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="toggleOpenAtLogin:" target="oE3-rO-9wI" id="4MA-zH-qZy"/>
-                                </connections>
-                            </button>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="ajp-ZJ-7EX" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="107" width="218" height="18"/>
-                                <buttonCell key="cell" type="check" title="Enable keyboard shortcut" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xI1-dq-8Q7">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="toggleEnableKeyboardShortcut:" target="oE3-rO-9wI" id="AI7-C1-OCJ"/>
-                                </connections>
-                            </button>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="oxy-oE-dHM" userLabel="Hide Text When Paused Button" customClass="HoverButton" customModule="SpotMenu" customModuleProvider="target">
-                                <rect key="frame" x="18" y="158" width="218" height="18"/>
-                                <buttonCell key="cell" type="check" title="Hide text when paused" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="VqI-2W-Oiy">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="toggleHideTextWhenPaused:" target="oE3-rO-9wI" id="ibs-QB-RYk"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="Trq-wg-nYW" firstAttribute="trailing" secondItem="yj4-VE-ueY" secondAttribute="trailing" id="1Hd-em-CfN"/>
                             <constraint firstItem="uyC-Ea-vx3" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="6R7-CI-P2R"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="pMj-ay-oKs" secondAttribute="trailing" constant="15" id="6S9-c1-e8t"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="pMj-ay-oKs" secondAttribute="trailing" constant="16" id="6S9-c1-e8t"/>
                             <constraint firstItem="ajp-ZJ-7EX" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="9mC-8O-mDe"/>
+                            <constraint firstItem="yj4-VE-ueY" firstAttribute="top" secondItem="Trq-wg-nYW" secondAttribute="bottom" constant="6" symbolic="YES" id="An3-eL-7gY"/>
                             <constraint firstItem="pMj-ay-oKs" firstAttribute="top" secondItem="oxy-oE-dHM" secondAttribute="bottom" constant="6" id="BQG-0d-91l"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="6XJ-fx-OKW" secondAttribute="trailing" constant="15" id="DXx-DS-2yC"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="6XJ-fx-OKW" secondAttribute="trailing" constant="16" id="DXx-DS-2yC"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="centerX" secondItem="hd7-oN-oUJ" secondAttribute="centerX" id="IDD-Fk-oH7"/>
-                            <constraint firstItem="p7v-xI-0VE" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="20" id="JKL-vT-QfS"/>
+                            <constraint firstItem="p7v-xI-0VE" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="12" id="JKL-vT-QfS"/>
                             <constraint firstItem="6XJ-fx-OKW" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="Jdg-A8-rs9"/>
-                            <constraint firstItem="Wcp-B2-r4h" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="20" id="KXe-yl-vwN"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="ajp-ZJ-7EX" secondAttribute="trailing" constant="15" id="Lvf-Yu-ixU"/>
+                            <constraint firstItem="Wcp-B2-r4h" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="12" id="KXe-yl-vwN"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="ajp-ZJ-7EX" secondAttribute="trailing" constant="16" id="Lvf-Yu-ixU"/>
                             <constraint firstItem="peo-tz-ZOw" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="8" id="MLC-zI-Lh1"/>
                             <constraint firstItem="oxy-oE-dHM" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="Ocf-Kg-47m"/>
+                            <constraint firstItem="Trq-wg-nYW" firstAttribute="top" secondItem="jNP-RL-5Pk" secondAttribute="bottom" constant="6" symbolic="YES" id="Pv0-lh-3tS"/>
                             <constraint firstItem="t8Z-Rd-MFu" firstAttribute="top" secondItem="ajp-ZJ-7EX" secondAttribute="bottom" constant="6" id="Pv5-PJ-Trj"/>
                             <constraint firstItem="pMj-ay-oKs" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="Ts6-KK-iPo"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="uyC-Ea-vx3" secondAttribute="trailing" constant="15" id="WIP-KU-mbi"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="uyC-Ea-vx3" secondAttribute="trailing" constant="16" id="WIP-KU-mbi"/>
                             <constraint firstItem="6XJ-fx-OKW" firstAttribute="top" secondItem="yj4-VE-ueY" secondAttribute="bottom" constant="6" id="ZIC-nn-XKI"/>
-                            <constraint firstAttribute="trailing" secondItem="p7v-xI-0VE" secondAttribute="trailing" constant="20" id="ZYo-k4-bVa"/>
+                            <constraint firstAttribute="trailing" secondItem="p7v-xI-0VE" secondAttribute="trailing" constant="27" id="ZYo-k4-bVa"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="Wcp-B2-r4h" secondAttribute="trailing" constant="15" id="Za4-H6-N45"/>
                             <constraint firstItem="oxy-oE-dHM" firstAttribute="top" secondItem="6XJ-fx-OKW" secondAttribute="bottom" constant="6" id="bTA-xb-rfk"/>
-                            <constraint firstAttribute="bottom" secondItem="5fe-rf-Xgk" secondAttribute="bottom" constant="12" id="cXX-yh-rDa"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="jNP-RL-5Pk" secondAttribute="trailing" constant="15" id="fJs-Hr-f4k"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="t8Z-Rd-MFu" secondAttribute="trailing" constant="15" id="gbg-F7-pNQ"/>
-                            <constraint firstItem="peo-tz-ZOw" firstAttribute="top" relation="greaterThanOrEqual" secondItem="t8Z-Rd-MFu" secondAttribute="bottom" constant="60" id="gpY-45-GIg"/>
-                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="p7v-xI-0VE" secondAttribute="bottom" priority="999" constant="20" id="jLU-Xm-cgU"/>
+                            <constraint firstAttribute="bottom" secondItem="5fe-rf-Xgk" secondAttribute="bottom" id="cXX-yh-rDa"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="jNP-RL-5Pk" secondAttribute="trailing" constant="19" id="fJs-Hr-f4k"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="t8Z-Rd-MFu" secondAttribute="trailing" constant="16" id="gbg-F7-pNQ"/>
+                            <constraint firstItem="peo-tz-ZOw" firstAttribute="top" relation="greaterThanOrEqual" secondItem="t8Z-Rd-MFu" secondAttribute="bottom" constant="105" id="gpY-45-GIg"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="p7v-xI-0VE" secondAttribute="bottom" priority="999" constant="297" id="jLU-Xm-cgU"/>
                             <constraint firstItem="yj4-VE-ueY" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="l7F-mq-so9"/>
                             <constraint firstItem="ajp-ZJ-7EX" firstAttribute="top" secondItem="uyC-Ea-vx3" secondAttribute="bottom" constant="8" id="lxD-pc-Ezh"/>
                             <constraint firstAttribute="bottom" secondItem="peo-tz-ZOw" secondAttribute="bottom" constant="7" id="m7Z-An-UUk"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="oxy-oE-dHM" secondAttribute="trailing" constant="15" id="nlH-hu-P5S"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="yj4-VE-ueY" secondAttribute="trailing" constant="15" id="pbj-hr-39m"/>
-                            <constraint firstItem="yj4-VE-ueY" firstAttribute="top" secondItem="jNP-RL-5Pk" secondAttribute="bottom" constant="6" id="ral-iv-Oy8"/>
-                            <constraint firstItem="p7v-xI-0VE" firstAttribute="leading" secondItem="5fe-rf-Xgk" secondAttribute="trailing" constant="15" id="u80-Cp-pew"/>
-                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="12" id="ujl-fF-faD"/>
-                            <constraint firstItem="uyC-Ea-vx3" firstAttribute="top" secondItem="pMj-ay-oKs" secondAttribute="bottom" constant="8" id="vCF-Ud-Mj8"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="oxy-oE-dHM" secondAttribute="trailing" constant="24" id="nlH-hu-P5S"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="yj4-VE-ueY" secondAttribute="trailing" constant="16" id="pbj-hr-39m"/>
+                            <constraint firstItem="yj4-VE-ueY" firstAttribute="top" secondItem="jNP-RL-5Pk" secondAttribute="bottom" constant="30" id="ral-iv-Oy8"/>
+                            <constraint firstItem="Trq-wg-nYW" firstAttribute="leading" secondItem="jNP-RL-5Pk" secondAttribute="leading" id="rof-Kk-jkp"/>
+                            <constraint firstItem="p7v-xI-0VE" firstAttribute="leading" secondItem="5fe-rf-Xgk" secondAttribute="trailing" constant="8" id="u80-Cp-pew"/>
+                            <constraint firstItem="5fe-rf-Xgk" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" id="ujl-fF-faD"/>
+                            <constraint firstItem="uyC-Ea-vx3" firstAttribute="top" secondItem="pMj-ay-oKs" secondAttribute="bottom" constant="10" id="vCF-Ud-Mj8"/>
                             <constraint firstItem="t8Z-Rd-MFu" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="vdf-ZI-cno"/>
                             <constraint firstItem="jNP-RL-5Pk" firstAttribute="top" secondItem="Wcp-B2-r4h" secondAttribute="bottom" constant="6" id="vhr-pF-cKx"/>
                             <constraint firstItem="jNP-RL-5Pk" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="xtI-PS-frH"/>
@@ -161,21 +181,22 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="enableKeyboardShortcutButton" destination="ajp-ZJ-7EX" id="Jdi-jM-C30"/>
-                        <outlet property="fixPopoverToTheRightButton" destination="pMj-ay-oKs" id="NgJ-xS-pbk"/>
-                        <outlet property="hideTextWhenPausedButton" destination="oxy-oE-dHM" id="PDf-gj-smd"/>
-                        <outlet property="moreInformation" destination="p7v-xI-0VE" id="7eX-9r-TWv"/>
-                        <outlet property="openAtLoginButton" destination="t8Z-Rd-MFu" id="1b4-1F-huS"/>
-                        <outlet property="showArtistButton" destination="Wcp-B2-r4h" id="bli-OR-ZjS"/>
-                        <outlet property="showPlayingIconButton" destination="yj4-VE-ueY" id="oGj-9H-EQJ"/>
-                        <outlet property="showSpotMenuIconButton" destination="6XJ-fx-OKW" id="P4Q-TX-iVj"/>
-                        <outlet property="showTitleButton" destination="jNP-RL-5Pk" id="Ha3-gh-lk5"/>
-                        <outlet property="withLoveFromKmikiyText" destination="peo-tz-ZOw" id="XTd-e1-WRr"/>
+                        <outlet property="enableKeyboardShortcutButton" destination="ajp-ZJ-7EX" id="tQO-ww-K3o"/>
+                        <outlet property="fixPopoverToTheRightButton" destination="pMj-ay-oKs" id="VUF-Km-mjg"/>
+                        <outlet property="hideTextWhenPausedButton" destination="oxy-oE-dHM" id="pta-gy-9gJ"/>
+                        <outlet property="moreInformation" destination="p7v-xI-0VE" id="8BD-Bc-UJK"/>
+                        <outlet property="openAtLoginButton" destination="t8Z-Rd-MFu" id="Q1t-am-Krw"/>
+                        <outlet property="showAlbumNameButton" destination="Trq-wg-nYW" id="RUe-EG-Xel"/>
+                        <outlet property="showArtistButton" destination="Wcp-B2-r4h" id="GJG-S8-CL4"/>
+                        <outlet property="showPlayingIconButton" destination="yj4-VE-ueY" id="9PG-sC-oRG"/>
+                        <outlet property="showSpotMenuIconButton" destination="6XJ-fx-OKW" id="92n-uz-iPp"/>
+                        <outlet property="showTitleButton" destination="jNP-RL-5Pk" id="QpS-HV-d1x"/>
+                        <outlet property="withLoveFromKmikiyText" destination="peo-tz-ZOw" id="tav-G0-Fbr"/>
                     </connections>
                 </viewController>
                 <customObject id="CLF-8K-5qC" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-700" y="990"/>
+            <point key="canvasLocation" x="-713.5" y="988.5"/>
         </scene>
     </scenes>
 </document>

--- a/SpotMenu/Preferences/Tabs/GeneralPreferencesVC.swift
+++ b/SpotMenu/Preferences/Tabs/GeneralPreferencesVC.swift
@@ -20,6 +20,7 @@ final class GeneralPreferencesVC: NSViewController {
     
     @IBOutlet fileprivate weak var showArtistButton: HoverButton!
     @IBOutlet fileprivate weak var showTitleButton: HoverButton!
+    @IBOutlet fileprivate weak var showAlbumNameButton: HoverButton!
     @IBOutlet fileprivate weak var showPlayingIconButton: HoverButton!
     @IBOutlet fileprivate weak var showSpotMenuIconButton: HoverButton!
     @IBOutlet fileprivate weak var fixPopoverToTheRightButton: HoverButton!
@@ -48,6 +49,7 @@ final class GeneralPreferencesVC: NSViewController {
     private func initLabels(){
         showArtistButton.title = NSLocalizedString("Show artist", comment: "")
         showTitleButton.title =  NSLocalizedString("Show title", comment: "")
+        showAlbumNameButton.title = NSLocalizedString("Show album title", comment: "")
         showPlayingIconButton.title = NSLocalizedString("Show playing icon", comment: "")
         showSpotMenuIconButton.title = NSLocalizedString("Show SpotMenu icon", comment: "")
         fixPopoverToTheRightButton.title = NSLocalizedString("Fix popover to the right", comment: "")
@@ -60,6 +62,7 @@ final class GeneralPreferencesVC: NSViewController {
     private func initButtonStates(){
         showArtistButton.state = NSControl.StateValue(rawValue: UserPreferences.showArtist.asState)
         showTitleButton.state =  NSControl.StateValue(rawValue: UserPreferences.showTitle.asState)
+        showAlbumNameButton.state = NSControl.StateValue(rawValue: UserPreferences.showAlbumName.asState)
         showPlayingIconButton.state = NSControl.StateValue(rawValue: UserPreferences.showPlayingIcon.asState)
         showSpotMenuIconButton.state = NSControl.StateValue(rawValue: UserPreferences.showSpotMenuIcon.asState)
         fixPopoverToTheRightButton.state = NSControl.StateValue(rawValue: UserPreferences.fixPopoverToTheRight.asState)
@@ -74,6 +77,9 @@ final class GeneralPreferencesVC: NSViewController {
         
         showTitleButton.mouseEnteredFunc = hoverShowTitle
         showTitleButton.mouseExitedFunc = hoverAway
+        
+        showAlbumNameButton.mouseEnteredFunc = hoverShowAlbumName
+        showAlbumNameButton.mouseEnteredFunc = hoverAway
         
         showPlayingIconButton.mouseEnteredFunc = hoverShowPlayingIcon
         showPlayingIconButton.mouseExitedFunc = hoverAway
@@ -103,6 +109,11 @@ final class GeneralPreferencesVC: NSViewController {
     
     @IBAction private func toggleShowTitle(_ sender: Any) {
         UserPreferences.showTitle = showTitleButton.state.asBool
+        postUpdateNotification()
+    }
+    
+    @IBAction private func toggleShowAlbumName(_ sender: Any) {
+        UserPreferences.showAlbumName = showAlbumNameButton.state.asBool
         postUpdateNotification()
     }
     
@@ -155,11 +166,15 @@ final class GeneralPreferencesVC: NSViewController {
 extension GeneralPreferencesVC {
     
     fileprivate func hoverShowArtist() {
-        moreInformation.stringValue = NSLocalizedString("When checked the Artist will be shown in the menu bar.", comment: "")
+        moreInformation.stringValue = NSLocalizedString("When checked the artist will be shown in the menu bar.", comment: "")
     }
     
     fileprivate func hoverShowTitle() {
-        moreInformation.stringValue = NSLocalizedString("When checked the Title will be shown in the menu bar.", comment: "")
+        moreInformation.stringValue = NSLocalizedString("When checked the title will be shown in the menu bar.", comment: "")
+    }
+    
+    fileprivate func hoverShowAlbumName() {
+        moreInformation.stringValue = NSLocalizedString("When checked the album name will be shown in the menu bar.", comment: "")
     }
     
     fileprivate func hoverShowPlayingIcon() {

--- a/SpotMenu/Preferences/UserPreferences.swift
+++ b/SpotMenu/Preferences/UserPreferences.swift
@@ -18,6 +18,8 @@ struct UserPreferences {
         
         static let showTitle = "showTitle"
         
+        static let showAlbumName = "showAlbumName"
+        
         static let showPlayingIcon = "showPlayingIcon"
         
         static let showSpotMenuIcon = "showSpotMenuIcon"
@@ -44,10 +46,19 @@ struct UserPreferences {
     
     static var showTitle: Bool {
         get {
-            return  UserPreferences.readSetting(key: Keys.showTitle)
+            return UserPreferences.readSetting(key: Keys.showTitle)
         }
         set {
             UserPreferences.setSetting(key: Keys.showTitle, value: newValue)
+        }
+    }
+    
+    static var showAlbumName: Bool {
+        get {
+            return UserPreferences.readSetting(key: Keys.showAlbumName)
+        }
+        set {
+            UserPreferences.setSetting(key: Keys.showAlbumName, value: newValue)
         }
     }
     
@@ -128,6 +139,7 @@ struct UserPreferences {
         
         if  UserPreferences.showArtist ||
             UserPreferences.showTitle ||
+            UserPreferences.showAlbumName ||
             UserPreferences.showPlayingIcon ||
             UserPreferences.showSpotMenuIcon ||
             UserPreferences.fixPopoverToTheRight ||
@@ -141,6 +153,7 @@ struct UserPreferences {
         UserPreferences.setSetting(key: Keys.hasBeenInitialized, value: true)
         UserPreferences.showArtist = true
         UserPreferences.showTitle = true
+        UserPreferences.showAlbumName = true
         UserPreferences.showPlayingIcon = true
         UserPreferences.showSpotMenuIcon = true
         UserPreferences.keyboardShortcutEnabled = true

--- a/SpotMenu/StatusBar/StatusItemBuilder.swift
+++ b/SpotMenu/StatusBar/StatusItemBuilder.swift
@@ -17,6 +17,8 @@ final class StatusItemBuilder {
     
     private var artist = ""
     
+    private var albumName = ""
+    
     private var playingIcon = ""
     
     private var state: PlayerState
@@ -81,6 +83,19 @@ final class StatusItemBuilder {
         return self
     }
     
+    func showAlbumName(v: Bool) -> StatusItemBuilder {
+        if !v {
+            albumName = ""
+            return self
+        } else if (state == PlayerState.paused && hideTitleArtistWhenPaused) {
+            albumName = ""
+            return self
+        } else if let albumName = SpotifyAppleScript.currentTrack.albumName {
+            self.albumName = albumName + " "
+        }
+        return self
+    }
+    
     func showPlayingIcon(v: Bool) -> StatusItemBuilder {
         if !v {
             playingIcon = ""
@@ -95,7 +110,9 @@ final class StatusItemBuilder {
     }
     
     func getString() -> String {
-        if( artist.count != 0 && title.count != 0 ) {
+        if (artist.count != 0 && title.count != 0 && albumName.count != 0) {
+            return "\(playingIcon)\(artist)- \(title)- \(albumName)"
+        } else if (artist.count != 0 && title.count != 0) {
             return "\(playingIcon)\(artist)- \(title)"
         }
         return "\(playingIcon)\(artist)\(title)"


### PR DESCRIPTION
I have added Album Name support to SpotMenu, of course with a preference to configure it. By default, it is set to true. I also updated the Xcode Workspace project format to be Xcode 8 and higher compatible only, since we don't target any macOS versions that still use Xcode 3.2.

I have tested this a bunch, and so far it works really well aside from the fact that I haven't figured out a way to hide the album name if it's the exact same as the song title unfortunately.