### PR TITLE
Change to previous fix on scroll bug

### DIFF
--- a/SpotMenu/CustomViews/ScrollingStatusItemView.swift
+++ b/SpotMenu/CustomViews/ScrollingStatusItemView.swift
@@ -102,7 +102,10 @@ class ScrollingStatusItemView: NSView {
 
     override func layout() {
         super.layout()
-        length = scrollingTextView.frame.width
+
+        if length != scrollingTextView.frame.width {
+            length = scrollingTextView.frame.width
+        }
     }
 }
 

--- a/SpotMenu/CustomViews/ScrollingTextView.swift
+++ b/SpotMenu/CustomViews/ScrollingTextView.swift
@@ -21,7 +21,11 @@ open class ScrollingTextView: NSView {
     open var spacing: CGFloat = 20
 
     /// Length of the scrolling text view
-    open var length: CGFloat = 0
+    open var length: CGFloat = 0 {
+        didSet {
+            updateTraits()
+        }
+    }
 
     /// Amount of time the text is delayed before scrolling
     open var delay: TimeInterval = 2 {


### PR DESCRIPTION
Turns out that the update is needed on length if the original title that is first presented is too small and shouldn't scroll. This should fix the old bug and the new one that resulted. I noticed it today.