### PR TITLE
added custom width property

### DIFF
--- a/SpotMenu.xcodeproj/project.pbxproj
+++ b/SpotMenu.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		64F112A721933ACB00753E83 /* ScrollingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F112A621933ACB00753E83 /* ScrollingTextView.swift */; };
 		64F112A821933CA400753E83 /* ScrollingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F112A621933ACB00753E83 /* ScrollingTextView.swift */; };
 		64F29A091F2E5F1100E48BBD /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 64F29A0B1F2E5F1100E48BBD /* Localizable.strings */; };
+		8DA8663423436CFF002915CE /* HoverTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA8663323436CFF002915CE /* HoverTextField.swift */; };
 		98C18916984B50AAD9E17661 /* Pods_SpotMenu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFCF0607F980ADD8D5D03FA /* Pods_SpotMenu.framework */; };
 		DB2C500E2199F94000932042 /* ScrollingStatusItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2C500D2199F94000932042 /* ScrollingStatusItemView.swift */; };
 		E2D35CCB1F60827B00EB5D67 /* CustomVisualEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648984831E5C21C200EA2234 /* CustomVisualEffect.swift */; };
@@ -217,6 +218,7 @@
 		64F112A621933ACB00753E83 /* ScrollingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingTextView.swift; sourceTree = "<group>"; };
 		64F29A0F1F2E5FDD00E48BBD /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6A999C2F782EFDE0675BE9DB /* Pods-SpotMenu.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpotMenu.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SpotMenu/Pods-SpotMenu.debug.xcconfig"; sourceTree = "<group>"; };
+		8DA8663323436CFF002915CE /* HoverTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverTextField.swift; sourceTree = "<group>"; };
 		ADFCF0607F980ADD8D5D03FA /* Pods_SpotMenu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SpotMenu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB2C500D2199F94000932042 /* ScrollingStatusItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingStatusItemView.swift; sourceTree = "<group>"; };
 		E2D35CCD1F60879700EB5D67 /* NSViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSViewExtension.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				64A908091EB784E400566ED1 /* HoverButton.swift */,
+				8DA8663323436CFF002915CE /* HoverTextField.swift */,
 				648984831E5C21C200EA2234 /* CustomVisualEffect.swift */,
 				64F112A621933ACB00753E83 /* ScrollingTextView.swift */,
 				DB2C500D2199F94000932042 /* ScrollingStatusItemView.swift */,
@@ -830,6 +833,7 @@
 				649D6C871F5C8A6F000A6DDF /* UpdatesPreferencesVC.swift in Sources */,
 				647087D51F2299F40054CC48 /* DDHotKeyAppDelegate.m in Sources */,
 				645F8E751F22B136007AEEE7 /* HudViewController.swift in Sources */,
+				8DA8663423436CFF002915CE /* HoverTextField.swift in Sources */,
 				647087D81F2299F40054CC48 /* DDHotKeyUtilities.m in Sources */,
 				2133243F1D7999180060D48C /* EventMonitor.swift in Sources */,
 				647087D71F2299F40054CC48 /* DDHotKeyTextField.m in Sources */,

--- a/SpotMenu/AppDelegate/AppDelegate.swift
+++ b/SpotMenu/AppDelegate/AppDelegate.swift
@@ -18,7 +18,6 @@ import Crashlytics
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private enum Constants {
         static let statusItemIconLength: CGFloat = 30
-        static let statusItemLength: CGFloat = 250
     }
 
     // MARK: - Properties
@@ -37,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastStatusTitle: String = ""
     private var removeHudTimer: Timer?
     private var musicPlayerManager: MusicPlayerManager!
+    private var statusItemLength: CGFloat = 250
 
     private lazy var statusItem: NSStatusItem = {
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -58,10 +58,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }()
 
     private lazy var handleLength: StatusItemLengthUpdate = { length in
-        if length < Constants.statusItemLength {
+        if length < self.statusItemLength {
             self.statusItem.length = length
         } else {
-            self.statusItem.length = Constants.statusItemLength
+            self.statusItem.length = self.statusItemLength
         }
     }
 
@@ -214,6 +214,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             updateTitle(newTitle: statusItemTitle)
         }
     }
+    
+    @objc func changeMaxWidth(newLength: Int) {
+        self.statusItemLength = CGFloat(newLength)
+        self.statusItem.length = self.statusItemLength
+       }
 
     // MARK: - Popover methods
 

--- a/SpotMenu/CustomViews/HoverTextField.swift
+++ b/SpotMenu/CustomViews/HoverTextField.swift
@@ -1,0 +1,50 @@
+//
+//  HoverTextField.swift
+//  SpotMenu
+//
+//  Created by Jakob Sudau on 01.10.19.
+//  Copyright © 2019 KM. All rights reserved.
+//
+
+import AppKit
+import Foundation
+
+final class HoverTextField: NSTextField {
+
+    // MARK: - Properties
+
+    private lazy var trackingArea: NSTrackingArea = self.createTrackingArea()
+
+    var mouseEnteredFunc: (() -> Void)?
+
+    var mouseExitedFunc: (() -> Void)?
+
+    // MARK: - Lifecycle methods
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        // set tracking area
+        addTrackingArea(trackingArea)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        // set tracking area
+        addTrackingArea(trackingArea)
+    }
+
+    deinit {
+        removeTrackingArea(trackingArea)
+    }
+
+    // MARK: - Mouse methods
+
+    override func mouseEntered(with _: NSEvent) {
+        mouseEnteredFunc?()
+    }
+
+    override func mouseExited(with _: NSEvent) {
+        mouseExitedFunc?()
+    }
+}
+

--- a/SpotMenu/Preferences/Tabs/GeneralPreferences.storyboard
+++ b/SpotMenu/Preferences/Tabs/GeneralPreferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="oE3-rO-9wI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="oE3-rO-9wI">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -55,7 +55,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="peo-tz-ZOw">
-                                <rect key="frame" x="6" y="7" width="119" height="17"/>
+                                <rect key="frame" x="6" y="7" width="117" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="with ♥ from kmikiy" id="UvV-6S-FUa">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -119,7 +119,7 @@
                                 </connections>
                             </button>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p7v-xI-0VE">
-                                <rect key="frame" x="250" y="282" width="205" height="34"/>
+                                <rect key="frame" x="250" y="284" width="205" height="32"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Hover over an option for more information" id="oHX-AN-IDS">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -129,14 +129,40 @@
                                     <action selector="toggleFixPopoverToTheRight:" target="oE3-rO-9wI" id="MJ7-5W-3Np"/>
                                 </connections>
                             </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gx8-D8-3as" customClass="HoverTextField" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="50" y="103" width="100" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Maximum width" id="ZBo-4i-2Vd">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LBM-af-QoK" customClass="HoverTextField" customModule="SpotMenu" customModuleProvider="target">
+                                <rect key="frame" x="11" y="100" width="33" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="33" id="qjo-rc-cLL"/>
+                                </constraints>
+                                <textFieldCell key="cell" lineBreakMode="charWrapping" truncatesLastVisibleLine="YES" selectable="YES" editable="YES" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="250" drawsBackground="YES" usesSingleLineMode="YES" id="lZX-KZ-Fyn">
+                                    <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="sUX-yV-lel"/>
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <action selector="changeCustomWidth:" target="oE3-rO-9wI" id="imL-iO-eaN"/>
+                                </connections>
+                            </textField>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="gx8-D8-3as" firstAttribute="leading" secondItem="LBM-af-QoK" secondAttribute="trailing" constant="8" id="0TR-3E-kbJ"/>
                             <constraint firstItem="uyC-Ea-vx3" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="6R7-CI-P2R"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="pMj-ay-oKs" secondAttribute="trailing" constant="15" id="6S9-c1-e8t"/>
                             <constraint firstItem="ajp-ZJ-7EX" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="9mC-8O-mDe"/>
                             <constraint firstItem="yj4-VE-ueY" firstAttribute="top" secondItem="Trq-wg-nYW" secondAttribute="bottom" constant="6" symbolic="YES" id="An3-eL-7gY"/>
                             <constraint firstItem="pMj-ay-oKs" firstAttribute="top" secondItem="oxy-oE-dHM" secondAttribute="bottom" constant="6" id="BQG-0d-91l"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="6XJ-fx-OKW" secondAttribute="trailing" constant="15" id="DXx-DS-2yC"/>
+                            <constraint firstItem="LBM-af-QoK" firstAttribute="top" secondItem="t8Z-Rd-MFu" secondAttribute="bottom" constant="8" id="Gl5-jM-TPP"/>
+                            <constraint firstItem="LBM-af-QoK" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="11" id="GvV-1J-ZGI"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="centerX" secondItem="hd7-oN-oUJ" secondAttribute="centerX" id="IDD-Fk-oH7"/>
                             <constraint firstItem="p7v-xI-0VE" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="12" id="JKL-vT-QfS"/>
                             <constraint firstItem="6XJ-fx-OKW" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="Jdg-A8-rs9"/>
@@ -147,6 +173,7 @@
                             <constraint firstItem="Trq-wg-nYW" firstAttribute="top" secondItem="jNP-RL-5Pk" secondAttribute="bottom" constant="6" symbolic="YES" id="Pv0-lh-3tS"/>
                             <constraint firstItem="t8Z-Rd-MFu" firstAttribute="top" secondItem="ajp-ZJ-7EX" secondAttribute="bottom" constant="6" id="Pv5-PJ-Trj"/>
                             <constraint firstItem="pMj-ay-oKs" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="Ts6-KK-iPo"/>
+                            <constraint firstItem="peo-tz-ZOw" firstAttribute="top" relation="greaterThanOrEqual" secondItem="gx8-D8-3as" secondAttribute="bottom" constant="80" id="W5R-Ye-E6p"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="uyC-Ea-vx3" secondAttribute="trailing" constant="15" id="WIP-KU-mbi"/>
                             <constraint firstItem="6XJ-fx-OKW" firstAttribute="top" secondItem="yj4-VE-ueY" secondAttribute="bottom" constant="6" id="ZIC-nn-XKI"/>
                             <constraint firstAttribute="trailing" secondItem="p7v-xI-0VE" secondAttribute="trailing" constant="20" id="ZYo-k4-bVa"/>
@@ -156,12 +183,12 @@
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="Trq-wg-nYW" secondAttribute="trailing" constant="15" id="dy9-IY-cl9"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="jNP-RL-5Pk" secondAttribute="trailing" constant="15" id="fJs-Hr-f4k"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="t8Z-Rd-MFu" secondAttribute="trailing" constant="15" id="gbg-F7-pNQ"/>
-                            <constraint firstItem="peo-tz-ZOw" firstAttribute="top" relation="greaterThanOrEqual" secondItem="t8Z-Rd-MFu" secondAttribute="bottom" priority="750" constant="105" id="gpY-45-GIg"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="p7v-xI-0VE" secondAttribute="bottom" priority="750" constant="20" id="jLU-Xm-cgU"/>
                             <constraint firstItem="yj4-VE-ueY" firstAttribute="leading" secondItem="hd7-oN-oUJ" secondAttribute="leading" constant="20" id="l7F-mq-so9"/>
                             <constraint firstItem="ajp-ZJ-7EX" firstAttribute="top" secondItem="uyC-Ea-vx3" secondAttribute="bottom" constant="8" id="lxD-pc-Ezh"/>
                             <constraint firstAttribute="bottom" secondItem="peo-tz-ZOw" secondAttribute="bottom" constant="7" id="m7Z-An-UUk"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="oxy-oE-dHM" secondAttribute="trailing" constant="15" id="nlH-hu-P5S"/>
+                            <constraint firstItem="gx8-D8-3as" firstAttribute="baseline" secondItem="LBM-af-QoK" secondAttribute="baseline" id="p0M-FY-WfX"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="leading" secondItem="yj4-VE-ueY" secondAttribute="trailing" constant="15" id="pbj-hr-39m"/>
                             <constraint firstItem="p7v-xI-0VE" firstAttribute="leading" secondItem="5fe-rf-Xgk" secondAttribute="trailing" constant="15" id="u80-Cp-pew"/>
                             <constraint firstItem="5fe-rf-Xgk" firstAttribute="top" secondItem="hd7-oN-oUJ" secondAttribute="top" constant="20" id="ujl-fF-faD"/>
@@ -174,6 +201,8 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="customWidthLabel" destination="gx8-D8-3as" id="GFb-Rf-shf"/>
+                        <outlet property="customWidthTextField" destination="LBM-af-QoK" id="IJn-2g-k6S"/>
                         <outlet property="enableKeyboardShortcutButton" destination="ajp-ZJ-7EX" id="tQO-ww-K3o"/>
                         <outlet property="fixPopoverToTheRightButton" destination="pMj-ay-oKs" id="VUF-Km-mjg"/>
                         <outlet property="hideTextWhenPausedButton" destination="oxy-oE-dHM" id="pta-gy-9gJ"/>
@@ -189,7 +218,7 @@
                 </viewController>
                 <customObject id="CLF-8K-5qC" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-713.5" y="973.5"/>
+            <point key="canvasLocation" x="-713.5" y="973"/>
         </scene>
     </scenes>
 </document>

--- a/SpotMenu/Preferences/Tabs/GeneralPreferencesVC.swift
+++ b/SpotMenu/Preferences/Tabs/GeneralPreferencesVC.swift
@@ -28,7 +28,9 @@ final class GeneralPreferencesVC: NSViewController {
     @IBOutlet fileprivate var hideTextWhenPausedButton: HoverButton!
     @IBOutlet fileprivate var moreInformation: NSTextField!
     @IBOutlet private var withLoveFromKmikiyText: NSTextField!
-
+    @IBOutlet weak var customWidthTextField: HoverTextField!
+    @IBOutlet weak var customWidthLabel: HoverTextField!
+    
     // MARK: - Lifecycle methods
 
     override func viewDidLoad() {
@@ -67,6 +69,7 @@ final class GeneralPreferencesVC: NSViewController {
         openAtLoginButton.state = NSControl.StateValue(rawValue: applicationIsInStartUpItems().asState)
         enableKeyboardShortcutButton.state = NSControl.StateValue(rawValue: UserPreferences.keyboardShortcutEnabled.asState)
         hideTextWhenPausedButton.state = NSControl.StateValue(rawValue: UserPreferences.hideTitleArtistWhenPaused.asState)
+        customWidthTextField.integerValue = UserPreferences.customWidth
     }
 
     private func initButtonHovers() {
@@ -96,6 +99,12 @@ final class GeneralPreferencesVC: NSViewController {
 
         enableKeyboardShortcutButton.mouseEnteredFunc = hoverEnableKeyboardShortcut
         enableKeyboardShortcutButton.mouseExitedFunc = hoverAway
+        
+        customWidthTextField.mouseEnteredFunc = hoverCustomWidth
+        customWidthTextField.mouseExitedFunc = hoverAway
+        
+        customWidthLabel.mouseEnteredFunc = hoverCustomWidth
+        customWidthLabel.mouseExitedFunc = hoverAway
     }
 
     // MARK: - IBActions
@@ -142,6 +151,19 @@ final class GeneralPreferencesVC: NSViewController {
             appDelegate.unregisterHotKey()
         }
     }
+    
+    @IBAction func changeCustomWidth(_ sender: HoverTextField) {
+        sender.window?.makeFirstResponder(self)
+        if ((1..<999).contains(sender.integerValue)) {
+            UserPreferences.customWidth = sender.integerValue
+            let appDelegate = NSApplication.shared.delegate as! AppDelegate
+            appDelegate.changeMaxWidth(newLength: sender.integerValue)
+        } else {
+            sender.integerValue = UserPreferences.customWidth
+        }
+    }
+    
+    
 }
 
 // MARK: - Hover button methods
@@ -182,6 +204,10 @@ extension GeneralPreferencesVC {
 
     fileprivate func hoverHideTitleWhenPaused() {
         moreInformation.stringValue = NSLocalizedString("Omits the current song artist and title from the menu bar when the music is paused.", comment: "")
+    }
+    
+    fileprivate func hoverCustomWidth() {
+        moreInformation.stringValue = NSLocalizedString("Set maximum width in pixels by entering a number between 1 and 999, the default value is 250. ", comment: "")
     }
 
     fileprivate func hoverAway() {

--- a/SpotMenu/Preferences/UserPreferences.swift
+++ b/SpotMenu/Preferences/UserPreferences.swift
@@ -25,6 +25,7 @@ struct UserPreferences {
         static let keyboardShortcutEnabled = "keyboardShortcutEnabled"
         static let hideTitleArtistWhenPaused = "hideTitleArtistWhenPaused"
         static let lastMusicPlayer = "lastMusicPlayer"
+        static let customWidth = "customWidth"
     }
 
     // MARK: - Properties
@@ -112,6 +113,18 @@ struct UserPreferences {
             UserPreferences.setSettingString(key: Keys.lastMusicPlayer, value: newValue)
         }
     }
+    
+    static var customWidth: Int {
+        get {
+            if let val = UserPreferences.readSettingInt(key: Keys.customWidth) {
+                return val
+            }
+            return 150
+        }
+        set {
+            UserPreferences.setSettingInt(key: Keys.customWidth, value: newValue)
+        }
+    }
 
     // MARK: - Public methods
 
@@ -134,6 +147,12 @@ struct UserPreferences {
         ud?.set(value, forKey: key)
         ud?.synchronize()
     }
+    
+    private static func setSettingInt(key: String, value: Int) {
+        let ud = UserDefaults(suiteName: "group.KMikiy.SpotMenu")
+        ud?.set(value, forKey: key)
+        ud?.synchronize()
+    }
 
     private static func readSetting(key: String) -> Bool {
         return UserDefaults.standard.bool(forKey: key)
@@ -142,6 +161,11 @@ struct UserPreferences {
     private static func readSettingString(key: String) -> String? {
         let ud = UserDefaults(suiteName: "group.KMikiy.SpotMenu")
         return ud?.string(forKey: key)
+    }
+    
+    private static func readSettingInt(key: String) -> Int? {
+        let ud = UserDefaults(suiteName: "group.KMikiy.SpotMenu")
+        return ud?.integer(forKey: key)
     }
 
     // MARK: - Init / migrate
@@ -175,6 +199,7 @@ struct UserPreferences {
         UserPreferences.showSpotMenuIcon = true
         UserPreferences.keyboardShortcutEnabled = true
         UserPreferences.hideTitleArtistWhenPaused = true
+        UserPreferences.customWidth = 250
     }
 }
 


### PR DESCRIPTION
Hello!
I added a custom width property so users can select a maximum width of SpotMenu.

This is viable for smaller screens or crowded menu bars, as the default behavior of SpotMenu is to disappear if there isn't enough space.

The property includes as custom `HoverTextField` to allow a hovering tooltip similar to the buttons as well as a `UserPreferences` entry to allow for persistence.

See attached gif.

Let me know what you think!

![ScreenRecording2019-10-01at14115](https://user-images.githubusercontent.com/721715/65962012-08f46480-e458-11e9-9d4a-ba7cfdfe912f.gif)



