### PR TITLE
Fix layout overflow issue of popover

### DIFF
--- a/SpotMenu/AppDelegate/AppDelegate.swift
+++ b/SpotMenu/AppDelegate/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private enum Constants {
         static let statusItemIconLength: CGFloat = 30
         static let statusItemLength: CGFloat = 250
+        static let menubarHeight: CGFloat = 22
     }
 
     // MARK: - Properties
@@ -311,13 +312,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showPopover(_: AnyObject?) {
+        
+        let popoverWidth = PopOverViewController.Constants.width
+        let popoverHeight = PopOverViewController.Constants.height
 
         let rect = statusItem.button?.window?.convertToScreen((statusItem.button?.frame)!)
-        let menubarHeight = rect?.height ?? 22
-        let height = hiddenController?.window?.frame.height ?? 300
-        let xOffset = UserPreferences.fixPopoverToTheRight ? ((hiddenController?.window?.contentView?.frame.minX)! - (statusItem.button?.frame.minX)!) : ((hiddenController?.window?.contentView?.frame.midX)! - (statusItem.button?.frame.midX)!)
-        let x = (rect?.origin.x)! - xOffset
+        let menubarHeight = rect?.height ?? Constants.menubarHeight
+        let height = hiddenController?.window?.frame.height ?? popoverHeight
+        let xOffset = UserPreferences.fixPopoverToTheRight
+            ? ((hiddenController?.window?.contentView?.frame.minX)! - (statusItem.button?.frame.minX)!)
+            : ((hiddenController?.window?.contentView?.frame.midX)! - (statusItem.button?.frame.midX)!)
+        var x = (rect?.origin.x)! - xOffset
         let y = (rect?.origin.y)! // - (hiddenController?.contentViewController?.view.frame.maxY)!
+        
+        if let screen = NSScreen.main {
+            let width = x + popoverWidth
+            let maxWidth = screen.frame.size.width
+            if width > maxWidth {
+                x = maxWidth - popoverWidth
+            }
+        }
+
         hiddenController?.window?.setFrameOrigin(NSPoint(x: x, y: y-height+menubarHeight))
         hiddenController?.showWindow(self)
         eventMonitor?.start()

--- a/SpotMenu/PopOver/PopOverVC.swift
+++ b/SpotMenu/PopOver/PopOverVC.swift
@@ -29,13 +29,21 @@ final class PopOverViewController: NSViewController {
     @IBOutlet private var rightTime: NSTextField!
     @IBOutlet private var musicPlayerButton: NSButton!
 
+    public enum Constants {
+         static let width: CGFloat = 300
+         static let height: CGFloat = 300
+     }
+    
     // MARK: - Lifecycle methods
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         defaultImage = artworkImageView.image
-        preferredContentSize = NSSize(width: 300, height: 300)
+        preferredContentSize = NSSize(
+            width: Constants.width,
+            height: Constants.height
+        )
         
         if #available(OSX 10.13, *) {
             view.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]


### PR DESCRIPTION
If the menu bar item is placed too far to the right, the popover overflows.
This PR solves this issue and you can see [previous](https://i.imgur.com/XlJ6QLO.mp4) and the [current](https://i.imgur.com/w8QtHLK.mp4) state.