### PR TITLE
Add version badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# SpotMenu ![demo](https://github.com/kmikiy/SpotMenu/blob/master/SpotMenu/Assets.xcassets/AppIcon.appiconset/spotmenu%20(5)-1.png?raw=true)
+# SpotMenu ![demo](https://github.com/kmikiy/SpotMenu/blob/master/SpotMenu/Assets.xcassets/AppIcon.appiconset/spotmenu%20(5)-1.png?raw=true) [![GitHub release](https://img.shields.io/github/release/kmikiy/SpotMenu.svg)](../../releases/latest)
+
 Spotify and iTunes in your menu bar
 
 # macOS MOJAVE BETA disclaimer


### PR DESCRIPTION
### Description
This adds the badge [![GitHub release](https://img.shields.io/github/release/kmikiy/SpotMenu.svg)](../../releases/latest) to README in order to show the latest version of SpotMenu

It is provided by http://shields.io/ and uses the [latest release of SpotMenu from GitHub](https://github.com/kmikiy/SpotMenu/releases/latest)

### Preview

![image](https://user-images.githubusercontent.com/22953777/73488530-64544600-43a9-11ea-9a91-a631f5ea8c99.png)
