### PR TITLE
Homebrew command update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can find all releases [here](https://github.com/kmikiy/SpotMenu/releases).
 via [Homebrew Cask](https://caskroom.github.io)
 
 ```sh
-brew cask install spotmenu
+brew install --cask spotmenu
 ```
 
 ## How to Build


### PR DESCRIPTION
Per https://github.com/Homebrew/brew/pull/8899, the `brew cask install` command has been deprecated in favor of `brew install --cask`.