### PR TITLE
Update homebrew install code snippet when using cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can find all releases [here](https://github.com/kmikiy/SpotMenu/releases).
 via [Homebrew Cask](https://caskroom.github.io)
 
 ```sh
-brew cask install spotmenu
+brew install --cask spotmenu
 ```
 
 ## How to Build


### PR DESCRIPTION
Homebrew's documentation has different or updated syntax for using cask:

**Old**
`brew cask install spotmenu`

**New**
`brew install --cask spotmenu`