### PR TITLE
Add support for long-form content

### DIFF
--- a/SpotMenu/Playback/AppleMusicController.swift
+++ b/SpotMenu/Playback/AppleMusicController.swift
@@ -54,7 +54,8 @@ class AppleMusicController: MusicPlayerController {
                 totalTime: totalTime,
                 currentTime: currentTime,
                 image: lastImage != nil ? Image(nsImage: lastImage!) : nil,
-                isLiked: nil
+                isLiked: nil,
+                longFormInfo: nil
             )
         }
 

--- a/SpotMenu/Preferences/MenuBarPreferencesView.swift
+++ b/SpotMenu/Preferences/MenuBarPreferencesView.swift
@@ -34,7 +34,7 @@ struct MenuBarPreferencesView: View {
                                 .transition(.opacity.combined(with: .move(edge: .top)))
                         }
 
-                        Toggle("Display Song Title", isOn: Binding(
+                        Toggle("Display Title", isOn: Binding(
                             get: { model.showTitle },
                             set: { newValue in
                                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -44,6 +44,20 @@ struct MenuBarPreferencesView: View {
                         ))
 
                         if model.showTitle {
+                            Picker(
+                                "Long-form Content",
+                                selection: $musicPlayerPreferencesModel
+                                    .longFormTitleStyle
+                            ) {
+                                ForEach(
+                                    LongFormTitleStyle.allCases,
+                                    id: \.self
+                                ) { style in
+                                    Text(style.displayName).tag(style)
+                                }
+                            }
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                            
                             Toggle("Hide Title When Paused", isOn: $model.hideTitleWhenPaused)
                                 .transition(.opacity.combined(with: .move(edge: .top)))
                         }

--- a/SpotMenu/Preferences/MusicPlayerPreferencesModel.swift
+++ b/SpotMenu/Preferences/MusicPlayerPreferencesModel.swift
@@ -29,6 +29,15 @@ class MusicPlayerPreferencesModel: ObservableObject {
         }
     }
 
+    @Published var longFormTitleStyle: LongFormTitleStyle {
+        didSet {
+            UserDefaults.standard.set(
+                longFormTitleStyle.rawValue,
+                forKey: "spotify.longFormTitleStyle"
+            )
+        }
+    }
+
     init() {
         let defaults = UserDefaults.standard
 
@@ -46,5 +55,20 @@ class MusicPlayerPreferencesModel: ObservableObject {
             defaults.object(forKey: "musicPlayer.likingEnabled") as? Bool ?? true
 
         spotifyClientID = defaults.string(forKey: "spotify.clientID")
+
+        if let storedRaw = defaults.string(
+            forKey: "spotify.longFormTitleStyle"
+        ), let storedStyle = LongFormTitleStyle(rawValue: storedRaw) {
+            longFormTitleStyle = storedStyle
+        } else if let legacyAppend =
+            defaults.object(
+                forKey: "spotify.showAudiobookChapterInTitle"
+            ) as? Bool
+        {
+            longFormTitleStyle =
+                legacyAppend ? .titleAndSegment : .titleOnly
+        } else {
+            longFormTitleStyle = .titleOnly
+        }
     }
 }


### PR DESCRIPTION
Adds support for audiobooks and podcasts. Also adds a picker in settings to allow user display the preferred information.

| Title Only | Chapter/Episode Only | Title + Chapter/Episode |
| --- | --- | --- |
| <img height="250" alt="Title Only" src="https://github.com/user-attachments/assets/2e188e5e-9cc5-45c1-8b44-5c0786428692" /> | <img height="250" alt="Chapter/Episode Only" src="https://github.com/user-attachments/assets/b57cc3d7-d69c-4eff-914c-23d755ae399a" /> | <img height="250" alt="Title + Chapter/Episode" src="https://github.com/user-attachments/assets/4fe2df29-816b-4778-b843-db65925c1f3c" /> |

| Long-form Content Settings |
| --- |
| <img width="400" alt="Long-form Content Settings" src="https://github.com/user-attachments/assets/72edce6b-16fa-4ca4-aa01-4a93d26bdbce" /> |
